### PR TITLE
Exit if the provided argument isn't a directory

### DIFF
--- a/find.php
+++ b/find.php
@@ -228,6 +228,10 @@
 	// Path to scan.
 	$path = realpath($args["params"][0]);
 
+	if (! is_dir($path)) {
+		exit("Sorry, the provided argument isn't a directory");
+	}
+
 	// What file extensions to look at (and keep tabs on the number of).
 	$exts = array(
 		"php" => 0,


### PR DESCRIPTION
Avoid errors like this one:

`php find.php test.php`

PHP Warning:  opendir(/private/tmp/php-short-open-tag-finder/test.php): failed to open dir: Not a directory in /private/tmp/php-short-open-tag-finder/find.php on line 73

Warning: opendir(/private/tmp/php-short-open-tag-finder/test.php): failed to open dir: Not a directory in /private/tmp/php-short-open-tag-finder/find.php on line 73

File extensions found in path (extension => # of instances):

Total files scanned:  0
Total lines scanned:  0
Total short open tag references:  0
Total files w/ short open tag references:  0